### PR TITLE
Fix: Cards Not Aligning Properly in Grid Layout (#9)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -173,20 +173,21 @@ button {
 }
 .cards {
     display: flex;
-    gap: 5px;
-    /* height: 60vh; */
-    max-height: 60vh;
-    overflow-y: auto;
     flex-wrap: wrap;
+    gap: 16px; /* increased gap for better spacing */
+    justify-content: flex-start; /* aligns items to the left */
+    padding: 10px;
+    box-sizing: border-box;
 }
 
 .card {
-    font-weight: 400;
-    width: 170px;
-    border-radius: 2px;
-    /* overflow: visible; */
-    line-height: 18px;
-    object-fit: contain;
+    width: calc(25% - 16px); /* 4 cards per row, adjust as needed */
+    min-width: 150px;
+    background-color: #1f1f1f;
+    border-radius: 5px;
+    overflow: hidden;
+    padding: 10px;
+    box-sizing: border-box;
 }
 
 .card p {


### PR DESCRIPTION
### Issue
Fixes #9  — Cards were misaligned and overflowing the container in grid layout.

### Changes Made
- Updated `.cards` and `.card` styles in `style.css`
- Used `flex-wrap`, `calc()` widths, and `box-sizing: border-box` for consistent layout
- Added inline comments beside CSS properties for better understanding and readability


### Result
 Cards are now evenly spaced, aligned properly, and no longer overflow the container.  
 Comments included for clarity on layout logic.
 
 @pratyush07-hub 
